### PR TITLE
Signaling order for on_connect event

### DIFF
--- a/ai-speech-realtime-sdk-python/src/oci_ai_speech_realtime/ai_service_speech_realtime_client.py
+++ b/ai-speech-realtime-sdk-python/src/oci_ai_speech_realtime/ai_service_speech_realtime_client.py
@@ -133,8 +133,8 @@ class RealtimeSpeechClient:
         async with websockets.connect(self.uri, ping_interval=None) as ws:
             self.connection = ws
             logger.info("Opened")
-            self.listener.on_connect()
             await self._send_credentials(ws)
+            self.listener.on_connect()
             await self._handle_messages(ws)
 
     async def _send_credentials(self, ws):


### PR DESCRIPTION
I've faced a bug where the client start sending bytes to the websocket before it gets stablished the connection.
As per my understanding this happened because the order on "async def connect(self)" was:
`self.listener.on_connect()
await self._send_credentials(ws)`

I'm suggesting to change that to:

`await self._send_credentials(ws)
self.listener.on_connect()`

If it is needed I can provide logs with the error before this correction.